### PR TITLE
Add .gitignore with common Node patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Node dependencies
+node_modules/
+
+# Log files
+server.log
+npm-debug.log
+*.log
+
+# Environment files
+.env
+.env.*
+
+# Build output
+/dist/
+coverage/
+
+# System files
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
## Summary
- add a repository-wide `.gitignore` to avoid committing transient build artifacts, logs, and environment files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f59f036408324b0b69e3e4eb428b3