### PR TITLE
Implement simple bots for quiz game

### DIFF
--- a/bots/simpleBot.js
+++ b/bots/simpleBot.js
@@ -1,0 +1,59 @@
+const { areAdjacent } = require('../src/utils');
+
+function makeId() {
+  return 'bot-' + Math.random().toString(36).slice(2, 9);
+}
+
+function createBot(name = 'Bot') {
+  return {
+    id: makeId(),
+    name,
+    score: 0,
+    ready: true,
+    territories: [],
+    isBot: true,
+    initialOrder: 0
+  };
+}
+
+function chooseRandomAnswer(question) {
+  const len = question?.choices?.length || 0;
+  return Math.floor(Math.random() * len);
+}
+
+function chooseDraftPick(room, bot) {
+  if (!room || !bot) return null;
+  const free = room.territories.filter(t => !t.owner);
+  if (free.length === 0) return null;
+
+  if (
+    room.draftData &&
+    room.draftData.firstPickTerritoryId &&
+    room.draftData.index === 0 &&
+    room.draftData.picksRemainingForPlayer === 1
+  ) {
+    const adjFree = free.filter(t =>
+      areAdjacent(room.draftData.firstPickTerritoryId, t.id)
+    );
+    if (adjFree.length > 0) {
+      return adjFree[Math.floor(Math.random() * adjFree.length)].id;
+    }
+  }
+
+  return free[Math.floor(Math.random() * free.length)].id;
+}
+
+function chooseAction(room, bot) {
+  if (!room || !bot) return null;
+  const options = [];
+  for (const tid of bot.territories || []) {
+    const neighbors = room.territories.filter(
+      t => areAdjacent(tid, t.id) && t.owner !== bot.id
+    );
+    neighbors.forEach(n => options.push({ from: tid, target: n.id }));
+  }
+  if (options.length === 0) return null;
+  return options[Math.floor(Math.random() * options.length)];
+}
+
+module.exports = { createBot, chooseRandomAnswer, chooseDraftPick, chooseAction };

--- a/public/script.js
+++ b/public/script.js
@@ -65,6 +65,7 @@ function renderHome() {
         <div id="home-card" class="card">
             <h1>Dobyvatel ČR</h1>
             <input id="name" class="input" placeholder="Tvé jméno" value="${state.myName || ''}" />
+            <input id="bots" class="input" type="number" min="0" max="5" value="0" placeholder="Počet botů" />
             <button id="create">Vytvořit hru</button>
             <input id="code" class="input" placeholder="Kód místnosti (6 znaků)" />
             <button id="join" class="secondary">Připojit se ke hře</button>
@@ -72,7 +73,8 @@ function renderHome() {
         </div>`;
     $("#create").onclick = () => {
         const name = $("#name").value.trim(); if (!name) { $("#home-error").textContent = "Zadejte prosím jméno."; return; }
-        $("#home-error").textContent = ""; state.myName = name; socket.emit("create", { name }, handleRoomResponse);
+        const bots = parseInt($("#bots").value, 10) || 0;
+        $("#home-error").textContent = ""; state.myName = name; socket.emit("create", { name, bots }, handleRoomResponse);
     };
     $("#join").onclick = () => {
         const name = $("#name").value.trim(); const code = $("#code").value.trim().toUpperCase(); if (!name || !code || code.length !== 6) { $("#home-error").textContent = "Zadejte jméno a platný 6místný kód."; return; }


### PR DESCRIPTION
## Summary
- add `bots/simpleBot.js` with basic bot AI
- let host choose number of bots when creating a game
- schedule bot answers, draft picks and actions automatically
- add bot count input in client

## Testing
- `npm install`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_683f5d946bfc8324ae477f792e18f48a