### PR TITLE
Add spectator handling on disconnect

### DIFF
--- a/bots/simpleBot.js
+++ b/bots/simpleBot.js
@@ -12,7 +12,8 @@ function createBot(name = 'Bot') {
     ready: true,
     territories: [],
     isBot: true,
-    initialOrder: 0
+    initialOrder: 0,
+    spectator: false
   };
 }
 


### PR DESCRIPTION
## Summary
- mark created players and bots with `spectator: false`
- convert disconnecting players to spectators instead of removing them
- ignore spectators when rotating turns or assigning host
- clean up room when all active players are gone
- skip spectators during drafting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f82c2ca9c8324a9ca98f2b8dfe334