### PR TITLE
Fix adjacency list for Czech regions

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1172,7 +1172,7 @@ socket.on("gameOver", ({ reason, players }) => {
 });
 
 const ADJACENCY_CLIENT = {
-    "PHA": ["STC"], "STC": ["PHA", "JHC", "PLK", "KVK", "ULK", "LBK", "HKK", "PAK", "VYS"], "JHC": ["STC", "PLK", "VYS", "JHM"], "PLK": ["STC", "JHC", "KVK", "ULK"], "KVK": ["STC", "PLK", "ULK"], "ULK": ["STC", "PLK", "KVK", "LBK"], "LBK": ["STC", "ULK", "HKK"], "HKK": ["STC", "LBK", "PAK", "OLK"], "PAK": ["STC", "HKK", "OLK", "VYS", "JHM"], "VYS": ["STC", "JHC", "PAK", "JHM", "ZLK", "OLK"], "JHM": ["JHC", "PAK", "VYS", "ZLK"], "ZLK": ["VYS", "JHM", "OLK", "MSK"], "OLK": ["HKK", "PAK", "VYS", "ZLK", "MSK"], "MSK": ["OLK", "ZLK"]
+    "PHA": ["STC"], "STC": ["PHA", "JHC", "PLK", "KVK", "ULK", "LBK", "HKK", "PAK", "VYS"], "JHC": ["STC", "PLK", "VYS", "JHM"], "PLK": ["STC", "JHC", "KVK"], "KVK": ["STC", "PLK", "ULK"], "ULK": ["STC", "KVK", "LBK"], "LBK": ["STC", "ULK", "HKK"], "HKK": ["STC", "LBK", "PAK"], "PAK": ["STC", "HKK", "VYS", "OLK", "JHM"], "VYS": ["STC", "JHC", "PAK", "JHM", "OLK"], "JHM": ["JHC", "VYS", "PAK", "OLK", "ZLK"], "ZLK": ["JHM", "OLK", "MSK"], "OLK": ["PAK", "VYS", "JHM", "ZLK", "MSK"], "MSK": ["OLK", "ZLK"]
 };
 
 // Add region names for display purposes

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,16 +3,16 @@ const ADJACENCY = {
   "PHA": ["STC"],
   "STC": ["PHA", "JHC", "PLK", "KVK", "ULK", "LBK", "HKK", "PAK", "VYS"],
   "JHC": ["STC", "PLK", "VYS", "JHM"],
-  "PLK": ["STC", "JHC", "KVK", "ULK"],
+  "PLK": ["STC", "JHC", "KVK"],
   "KVK": ["STC", "PLK", "ULK"],
-  "ULK": ["STC", "PLK", "KVK", "LBK"],
+  "ULK": ["STC", "KVK", "LBK"],
   "LBK": ["STC", "ULK", "HKK"],
-  "HKK": ["STC", "LBK", "PAK", "OLK"],
+  "HKK": ["STC", "LBK", "PAK"],
   "PAK": ["STC", "HKK", "OLK", "VYS", "JHM"],
-  "VYS": ["STC", "JHC", "PAK", "JHM", "ZLK", "OLK"],
-  "JHM": ["JHC", "PAK", "VYS", "ZLK"],
-  "ZLK": ["VYS", "JHM", "OLK", "MSK"],
-  "OLK": ["HKK", "PAK", "VYS", "ZLK", "MSK"],
+  "VYS": ["STC", "JHC", "PAK", "JHM", "OLK"],
+  "JHM": ["JHC", "VYS", "PAK", "OLK", "ZLK"],
+  "ZLK": ["JHM", "OLK", "MSK"],
+  "OLK": ["PAK", "VYS", "JHM", "ZLK", "MSK"],
   "MSK": ["OLK", "ZLK"]
 };
 


### PR DESCRIPTION
## Summary
- correct which regions are neighbors in the server-side utils
- mirror updated adjacency in the client script

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683f84a13788832484b2a0d80704b408