### PR TITLE
Add player results list to reveal overlay

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -513,3 +513,28 @@ body.dark { --accent-rgb: 96, 165, 250; }
     font-weight: bold;
     font-size: 1.1rem;
 }
+
+/* --- Reveal results --- */
+.player-result-list {
+    list-style: none;
+    padding: 0;
+    margin-top: 1rem;
+}
+.player-result-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.25rem 0;
+}
+.result-icon.correct { color: #10b981; }
+.result-icon.incorrect { color: #ef4444; }
+.result-icon.timeout { color: var(--text-muted); }
+.answer-time {
+    margin-left: auto;
+    font-size: 0.9rem;
+    color: var(--text-muted);
+}
+.player-result-item.fastest .answer-time {
+    color: var(--accent);
+    font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- enhance reveal handler in `public/script.js` to store and display detailed results
- render list of players with icons and answer times after each question
- style result list in `public/style.css`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f8961919483249e17357a4ecdcfcf