### PR TITLE
Add capital lives system

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -74,7 +74,7 @@ function Lobby({ roomId, players, onReady, onStart, myId }) {
   );
 }
 
-function GameBoard({ players }) {
+function GameBoard({ players, territories }) {
   return (
     React.createElement('div', { id: 'game-board' },
       React.createElement('div', { id: 'map-wrapper' },
@@ -83,7 +83,11 @@ function GameBoard({ players }) {
       React.createElement('div', { id: 'score-panel' },
         React.createElement('h3', null, 'Sk\u00f3re'),
         React.createElement('ul', null,
-          players.map(p => React.createElement('li', { key: p.id }, `${p.name}: ${p.score}`))
+          players.map(p => {
+            const cap = territories.find(t => t.id === p.capitalId);
+            const lives = cap ? cap.lives : 0;
+            return React.createElement('li', { key: p.id }, `${p.name}: ${p.score} ${p.capitalId ? '(' + p.capitalId + ' ' + lives + ')' : ''}`);
+          })
         )
       )
     )
@@ -160,6 +164,7 @@ function App() {
     myId: '',
     myName: localStorage.getItem('dobyvatel_playerName') || '',
     players: [],
+    territories: [],
     question: null,
     revealData: null,
     phase: 'lobby'
@@ -224,7 +229,7 @@ function App() {
       myId: state.myId
     });
   } else {
-    content = React.createElement(GameBoard, { players: state.players });
+    content = React.createElement(GameBoard, { players: state.players, territories: state.territories || [] });
   }
 
   return React.createElement(React.Fragment, null,

--- a/src/utils.js
+++ b/src/utils.js
@@ -34,10 +34,11 @@ function serializeRoomState(room) {
       name: p.name,
       score: p.score || 0,
       team: p.team,
+      capitalId: p.capitalId || null,
       territories: Array.isArray(p.territories) ? p.territories : []
     })),
     initialPlayerOrder: initialPlayerOrderSummary,
-    territories: territories.map(t => ({ id: t.id, owner: t.owner })),
+    territories: territories.map(t => ({ id: t.id, owner: t.owner, lives: t.lives })),
     turnData: room.turnData ? {
       type: room.turnData.type,
       targetTerritoryId: room.turnData.targetTerritoryId,

--- a/test/serializeRoomState.test.js
+++ b/test/serializeRoomState.test.js
@@ -42,16 +42,16 @@ describe('serializeRoomState', () => {
       turnIndex: 0,
       lastResult: 'some result',
       players: [
-        { id: 'a1', name: 'Alice', score: 3, team: undefined, territories: ['PHA'] },
-        { id: 'b2', name: 'Bob', score: 0, team: undefined, territories: [] }
+        { id: 'a1', name: 'Alice', score: 3, team: undefined, capitalId: null, territories: ['PHA'] },
+        { id: 'b2', name: 'Bob', score: 0, team: undefined, capitalId: null, territories: [] }
       ],
       initialPlayerOrder: [
         { id: 'a1', name: 'Alice', initialOrder: 0, team: undefined },
         { id: 'b2', name: 'Bob', initialOrder: 1, team: undefined }
       ],
       territories: [
-        { id: 'PHA', owner: 'a1' },
-        { id: 'STC', owner: null }
+        { id: 'PHA', owner: 'a1', lives: undefined },
+        { id: 'STC', owner: null, lives: undefined }
       ],
       turnData: {
         type: 'attack',


### PR DESCRIPTION
## Summary
- track territory `lives` on the server
- mark the first claimed region as a player's capital
- reduce lives during duels and eliminate players when their capital falls
- expose lives via `serializeRoomState`
- display remaining capital lives in the React UI
- update tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683f8a56da1c8324a4951e7388e5ccc7